### PR TITLE
Add toolbar with a colored Activity button and a working Stop button

### DIFF
--- a/css/activity.css
+++ b/css/activity.css
@@ -1,0 +1,1 @@
+/* Your styles go here */

--- a/images/activity-stop.svg
+++ b/images/activity-stop.svg
@@ -1,0 +1,6 @@
+<?xml version="1.0" ?><!DOCTYPE svg  PUBLIC '-//W3C//DTD SVG 1.1//EN'  'http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd' [
+	<!ENTITY stroke_color "#010101">
+	<!ENTITY fill_color "#FFFFFF">
+]><svg enable-background="new 0 0 55 55" height="55px" version="1.1" viewBox="0 0 55 55" width="55px" x="0px" xml:space="preserve" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" y="0px"><g display="block" id="activity-stop">
+	<path d="M36.822,5H18.181L5.002,18.182V36.82L18.181,50h18.642l13.176-13.18V18.182L36.822,5z    M35.75,35.414h-15.5v-15.5h15.5V35.414z" display="inline" fill="&fill_color;"/>
+</g></svg>

--- a/index.html
+++ b/index.html
@@ -1,8 +1,33 @@
 <!DOCTYPE html>
 <html>
 <head>
-    <meta charset="utf-8"/>
-    <script data-main="js/activity" src="lib/require.js"></script>
+  <meta charset="utf-8"/>
+  <title>My Activity</title>
+  <link rel="stylesheet" href="lib/sugar-html-graphics/css/sugar.css">
+  <link rel="stylesheet" href="css/activity.css">
+  <script data-main="js/activity" src="lib/require.js"></script>
 </head>
 <body>
+
+  <div id="toolbar">
+
+    <button id="activity-button" title="My Activity">
+      <img src="activity/activity-icon.svg" alt="My Activity"/>
+    </button>
+
+    <!-- Add more buttons here -->
+
+    <!-- Buttons with class="pull-right" will be right aligned -->
+    <button id="stop-button" class="pull-right" title="Stop">
+      <img src="images/activity-stop.svg" alt="Stop"/>
+    </button>
+
+  </div>
+
+
+  <!-- The content of your activity goes inside the canvas -->
+  <div id="canvas">Hello World</div>
+
+
+</body>
 </html>

--- a/js/main.js
+++ b/js/main.js
@@ -1,2 +1,42 @@
 define(function (require) {
+
+    var activity = require("sugar-html-core/activity");
+    var icons = require("sugar-html-graphics/icons");
+
+    // Colorize the activity icon.
+
+    var activityIcon = document.getElementById("activity-button")
+        .getElementsByTagName("img")[0];
+
+    var iconInfo = {
+        "uri": activityIcon.src
+    };
+
+    function colorizeActivityIcon(iconInfo) {
+        icons.load(iconInfo, function (data) {
+            activityIcon.src = data;
+        });
+    }
+
+    try {
+        activity.getXOColor(function (data) {
+            iconInfo.strokeColor = data[0];
+            iconInfo.fillColor = data[1];
+            colorizeActivityIcon(iconInfo);
+        });
+    }
+    catch (err) {
+        // Sugar API not available, use sample colors:
+        iconInfo.strokeColor = "#00A0FF";
+        iconInfo.fillColor = "#8BFF7A";
+        colorizeActivityIcon(iconInfo);
+    }
+
+    // Make the activity stop with the stop button.
+
+    var stopButton = document.getElementById("stop-button");
+    stopButton.onclick = function () {
+        activity.close();
+    };
+
 });


### PR DESCRIPTION
This change will work only if the libraries sugar-html-core and
sugar-html-graphics are added (with volo add).  We can consider adding
them directly to this repo, as git submodules.

The js code to colorize the activity icon may be too large.  We could
provide a better API.

Ideally we should define the SVG graphics in the CSS.  Looks doable:
Daniel Narvaez did it in Agora.  But I couldn't in my pet activity,
seems that the content inside the the "data:" uri scheme is bad.  Here
is the branch in which I was trying:

https://github.com/manuq/clockjs/tree/colorize-css
