### PR TITLE
Remove dependency on sugar-html-bus

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,6 @@
   "volo": {
     "baseUrl": "lib",
     "dependencies": {
-      "sugar-html-bus": "github:sugarlabs/sugar-html-bus/master",
       "sugar-html-activity": "github:sugarlabs/sugar-html-activity/master",
       "sugar-html-graphics": "github:sugarlabs/sugar-html-graphics/master",
       "domReady": "github:requirejs/domReady/2.0.1"


### PR DESCRIPTION
We don't use it directly, sugar-html-activity should
depend on it.
