### PR TITLE
Use the corresponding CSS for the screen

### DIFF
--- a/index.html
+++ b/index.html
@@ -4,7 +4,10 @@
 <head>
 <meta charset="utf-8" />
 <title>My Activity</title>
-<link rel="stylesheet" href="lib/sugar-web/graphics/css/sugar.css">
+<link rel="stylesheet" media="not screen and (device-width: 1200px) and (device-height: 900px)"
+      href="lib/sugar-web/graphics/css/sugar-96dpi.css">
+<link rel="stylesheet" media="screen and (device-width: 1200px) and (device-height: 900px)"
+      href="lib/sugar-web/graphics/css/sugar-200dpi.css">
 <link rel="stylesheet" href="css/activity.css">
 <script data-main="js/loader" src="lib/require.js"></script>
 </head>


### PR DESCRIPTION
Ideally we should use a proper media-query that considers the DPI like
"min-resolution: 200dpi".  But experience shows that WebKitGTK1 (nor
Firefox) get the right DPI, at least in XO screens.
